### PR TITLE
Export documentation to docsy site

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,46 @@
+name: "Run: Build documentation"
+
+permissions: {}
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}-doc-${{ github.run_id }}"
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+    paths:
+      - 'doc/**'
+  push:
+    paths:
+      - 'doc/**'
+
+jobs:
+  doc:
+    permissions:
+      contents: write
+    concurrency:
+      group: "doc-${{ inputs.run_id }}"
+      cancel-in-progress: true
+    uses: antirs/sh.wrap/.github/workflows/actions.yml@actions
+    with:
+      run_id: "doc/actions"
+      script_hugo_site: "./_actions/src/docsy-site.sh"
+      hugo_build_args: "--tags\\nextended"
+      docs_dir: "./doc/content"
+      site_dir: "./doc"
+      public_dir: "./public"
+      public_cache: "doc-${{ github.run_id }}"
+      gh_pages_repo: "https://github.com/ekotik/sh.wrap"
+      gh_pages_branch: "gh-pages/sh.wrap"
+  update-submodules:
+    permissions:
+      contents: write
+    needs:
+      - doc
+    uses: antirs/sh.wrap/.github/workflows/update-submodules.yml@actions
+    with:
+      run_id: "doc/update-submodules"
+      git_repo: "https://github.com/ekotik/sh.wrap"
+      git_branch: "gh-pages/sh.wrap"
+      git_repo_dir: "./sh.wrap"

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -22,7 +22,7 @@ jobs:
     concurrency:
       group: "doc-${{ inputs.run_id }}"
       cancel-in-progress: true
-    uses: antirs/sh.wrap/.github/workflows/actions.yml@actions
+    uses: ekotik/sh.wrap/.github/workflows/actions.yml@actions
     with:
       run_id: "doc/actions"
       script_hugo_site: "./_actions/src/docsy-site.sh"
@@ -38,7 +38,7 @@ jobs:
       contents: write
     needs:
       - doc
-    uses: antirs/sh.wrap/.github/workflows/update-submodules.yml@actions
+    uses: ekotik/sh.wrap/.github/workflows/update-submodules.yml@actions
     with:
       run_id: "doc/update-submodules"
       git_repo: "https://github.com/ekotik/sh.wrap"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docsy"]
+	path = doc/themes/docsy
+	url = https://github.com/google/docsy

--- a/doc/config/_default/config.yaml
+++ b/doc/config/_default/config.yaml
@@ -1,0 +1,99 @@
+languageCode: "en-us"
+title: "sh.wrap"
+theme: ["docsy"]
+
+disableKinds: [RSS,sitemap]
+
+imaging:
+  anchor: smart
+  quality: 75
+  resampleFilter: CatmullRom
+
+taxonomies:
+  tags: "tags"
+  category: "categories"
+
+markup:
+  defaultMarkdownHandler: goldmark
+  goldmark:
+    parser:
+      autoHeadingID: true
+      autoHeadingIDType: github
+    renderer:
+      unsafe: true
+  tableOfContents:
+    endLevel: 2
+    ordered: false
+    startLevel: 1
+  highlight:
+    codeFences: true
+    guessSyntax: true
+    noClasses: true
+    style: tango
+    tabWidth: 4
+
+module:
+  imports:
+    - path: "github.com/ekotik/sh.wrap/doc/docs"
+      disabled: false
+      mounts:
+        - source: "./doc/"
+          target: "content/docs/"
+    - path: "github.com/ekotik/sh.wrap/doc/actions"
+      disabled: false
+      mounts:
+        - source: "./doc/actions/"
+          target: "content/docs/actions/"
+    - path: "github.com/ekotik/sh.wrap/doc/project"
+      disabled: false
+      mounts:
+        - source: "./doc/project/"
+          target: "content/docs/project/"
+    - path: "github.com/ekotik/sh.wrap/doc/wiki"
+      disabled: false
+      mounts:
+        - source: "./"
+          target: "content/wiki/"
+
+caches:
+  modules:
+    dir: ":cacheDir/modules"
+    maxAge: "2m"
+
+cascade:
+  - type: "docs"
+    tags: ["docs"]
+    _target:
+      kind: "*"
+      path: "/docs/**"
+  - type: "docs"
+    tags: ["wiki"]
+    _target:
+      kind: "*"
+      path: "/wiki/**"
+  - type: "docs"
+    tags: ["project"]
+    _target:
+      kind: "*"
+      path: "/docs/project/**"
+
+params:
+  copyright: sh.wrap
+  links:
+    user:
+      - name: "sh.wrap"
+        url: "https://github.com/ekotik/sh.wrap"
+        icon: fa-brands fa-github
+        desc: "sh.wrap"
+  ui:
+    sidebar_menu_compact: true
+    sidebar_menu_foldable: false
+    sidebar_search_disable: true
+    breadcrumb_disable: false
+    readingtime:
+      enable: false
+
+outputs:
+  home: [HTML]
+  page: [HTML]
+  section: [HTML]

--- a/doc/config/development/config.yaml
+++ b/doc/config/development/config.yaml
@@ -1,0 +1,1 @@
+baseURL: "http://localhost/sh.wrap/"

--- a/doc/config/production/config.yaml
+++ b/doc/config/production/config.yaml
@@ -1,0 +1,1 @@
+baseURL: "https://ekotik.github.io/sh.wrap/"

--- a/doc/content/_index.md
+++ b/doc/content/_index.md
@@ -1,0 +1,12 @@
+---
+title: sh.wrap
+---
+
+{{< blocks/section color="primary" type="features">}}
+{{% blocks/feature icon="fa-lightbulb" title="Documentation" url="/sh.wrap/docs/" %}}
+{{% /blocks/feature %}}
+{{% blocks/feature icon="fa-brands fa-wikipedia-w" title="Wiki" url="/sh.wrap/wiki/" %}}
+{{% /blocks/feature %}}
+{{% blocks/feature icon="fa-brands fa-github" title="Contributions welcome!" url="https://github.com/ekotik/sh.wrap" %}}
+{{% /blocks/feature %}}
+{{< /blocks/section >}}

--- a/doc/content/docs/_index.md
+++ b/doc/content/docs/_index.md
@@ -1,0 +1,4 @@
+---
+title: Documentation
+menu: {main: {name: "Docs", weight: 40 }}
+---

--- a/doc/go.mod
+++ b/doc/go.mod
@@ -1,0 +1,11 @@
+module github.com/ekotik/sh.wrap/doc
+
+go 1.18
+
+replace github.com/ekotik/sh.wrap/doc/docs => github.com/ekotik/sh.wrap latest
+
+replace github.com/ekotik/sh.wrap/doc/actions => github.com/antirs/sh.wrap v0.0.0-actions
+
+replace github.com/ekotik/sh.wrap/doc/project => github.com/neurodiff/sh.wrap v0.0.0-project
+
+replace github.com/ekotik/sh.wrap/doc/wiki => github.com/ekotik/sh.wrap.wiki latest

--- a/doc/go.mod
+++ b/doc/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 replace github.com/ekotik/sh.wrap/doc/docs => github.com/ekotik/sh.wrap latest
 
-replace github.com/ekotik/sh.wrap/doc/actions => github.com/antirs/sh.wrap v0.0.0-actions
+replace github.com/ekotik/sh.wrap/doc/actions => github.com/ekotik/sh.wrap v0.0.0-actions
 
 replace github.com/ekotik/sh.wrap/doc/project => github.com/neurodiff/sh.wrap v0.0.0-project
 


### PR DESCRIPTION
Export documentation to docsy site

This PR add hugo config and docsy theme (as submodule).
Site generated with GH action and pushed to gh-pages/sh.wrap branch.
Hugo modules is used to add documentation from other repositories.

Exactly same changes on the same base generated [site](https://github.com/antirs/sh.wrap/suites/9008180736/artifacts/415194770) successfully [here](https://github.com/antirs/sh.wrap/pull/1).
The only changes were made to GH pages site (for permissions) in the [second commit](https://github.com/antirs/sh.wrap/pull/1/commits/10943bc0873128213ab79f6c867dcd2a3fe22505)
