### PR TITLE
Fix output directory doesn't exists in org-to-md script

### DIFF
--- a/src/org-to-md.sh
+++ b/src/org-to-md.sh
@@ -50,7 +50,7 @@ if [[ $# -eq 1 ]]; then
 fi
 
 in_dir=$(realpath "$1")
-out_dir=$(realpath "$2")
+out_dir=$(realpath -m "$2")
 clean="$3"
 
 function org_to_md()


### PR DESCRIPTION
This PR removes realpath check for path existence and let script to work with not yet existing output directory (by creating it later).
