### PR TITLE
Add PoC prototype with core functionality

### DIFF
--- a/src/common.sh
+++ b/src/common.sh
@@ -4,7 +4,7 @@
 # Common global, environment variables and function definitions for them.
 
 declare -x _SHWRAP_MODULE_PATH=~/.sh.wrap
-declare -x _SHWRAP_MODULE="${_SHWRAP_MODULE_PATH}"/sh.wrap/module.sh
+declare -x _SHWRAP_MODULE="${SHWRAP_INIT_DIR}"/module.sh
 declare -x _SHWRAP_TMP_PATH=/tmp/sh.wrap
 declare -ax SHWRAP_MODULE_PATHS
 

--- a/src/common.sh
+++ b/src/common.sh
@@ -17,6 +17,17 @@ declare -ax SHWRAP_MODULE_PATHS
 [[ -n "${SHWRAP_MODULE_PATHS[*]}" ]] ||
 	SHWRAP_MODULE_PATHS+=(.)
 
+declare -ax _SHWRAP_FD_RANGE=(666 777)
+declare -x _SHWRAP_FD_RANDOM_MAXTRY=10
+declare -x _SHWRAP_FD_FUNC=__shwrap_get_fd_sequential
+
+[[ -n "${SHWRAP_FD_RANGE[*]}" ]] ||
+	SHWRAP_FD_RANGE+=("${_SHWRAP_FD_RANGE[@]}")
+[[ -n "${SHWRAP_FD_RANDOM_MAXTRY}" ]] ||
+	SHWRAP_FD_RANDOM_MAXTRY="${_SHWRAP_FD_RANDOM_MAXTRY}"
+[[ -n "${SHWRAP_FD_FUNC}" ]] ||
+	SHWRAP_FD_FUNC="${_SHWRAP_FD_FUNC}"
+
 declare -A _shwrap_modules
 declare -A _shwrap_modules_deps
 declare -A _shwrap_modules_hashes
@@ -25,6 +36,7 @@ declare -A _shwrap_modules_partials
 declare -A _shwrap_modules_parts
 declare -A _shwrap_modules_paths
 declare -A _shwrap_scope
+declare -a _shwrap_fds
 declare -a _shwrap_modules_stack
 
 [[ -v _shwrap_scope[.] ]] || _shwrap_scope+=([.]=$(declare -px))
@@ -40,5 +52,6 @@ function __shwrap_clean()
 	declare -Ag _shwrap_modules_parts=()
 	declare -Ag _shwrap_modules_paths=()
 	declare -Ag _shwrap_scope=([.]=$(declare -px))
+	declare -ag _shwrap_fds=()
 	declare -ag _shwrap_modules_stack=()
 }

--- a/src/common.sh
+++ b/src/common.sh
@@ -4,6 +4,12 @@
 # common.sh
 # Common global, environment variables and function definitions for them.
 
+# environment variables
+declare _SHWRAP_ID
+_SHWRAP_ID=$(__shwrap_random_bytes 256 | __shwrap_md5sum)
+
+[[ -n "${SHWRAP_ID}" ]] || declare -x SHWRAP_ID="${_SHWRAP_ID}"
+
 declare -x _SHWRAP_MODULE_PATH=~/.sh.wrap
 declare -x _SHWRAP_MODULE="${SHWRAP_INIT_DIR}"/module.sh
 declare -x _SHWRAP_TMP_PATH=/tmp/sh.wrap

--- a/src/common.sh
+++ b/src/common.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# sh.wrap - module system for bash
+# common.sh
+# Common global, environment variables and function definitions for them.
+
+declare -x _SHWRAP_MODULE_PATH=~/.sh.wrap
+declare -x _SHWRAP_MODULE="${_SHWRAP_MODULE_PATH}"/sh.wrap/module.sh
+declare -x _SHWRAP_TMP_PATH=/tmp/sh.wrap
+declare -ax SHWRAP_MODULE_PATHS
+
+[[ -n "${SHWRAP_MODULE_PATH}" ]] ||
+	declare -x SHWRAP_MODULE_PATH="${_SHWRAP_MODULE_PATH}"
+[[ -n "${SHWRAP_MODULE}" ]] ||
+	declare -x SHWRAP_MODULE="${_SHWRAP_MODULE}"
+[[ -n "${SHWRAP_TMP_PATH}" ]] ||
+	declare -x SHWRAP_TMP_PATH="${_SHWRAP_TMP_PATH}"
+[[ -n "${SHWRAP_MODULE_PATHS[*]}" ]] ||
+	SHWRAP_MODULE_PATHS+=(.)
+
+declare -A _shwrap_modules
+declare -A _shwrap_modules_deps
+declare -A _shwrap_modules_hashes
+declare -A _shwrap_modules_names
+declare -A _shwrap_modules_partials
+declare -A _shwrap_modules_parts
+declare -A _shwrap_modules_paths
+declare -A _shwrap_scope
+declare -a _shwrap_modules_stack
+
+[[ -v _shwrap_scope[.] ]] || _shwrap_scope+=([.]=$(declare -px))
+[[ -d "${SHWRAP_TMP_PATH}" ]] || mkdir -p "${SHWRAP_TMP_PATH}"
+
+function __shwrap_clean()
+{
+	declare -Ag _shwrap_modules=()
+	declare -Ag _shwrap_modules_deps=()
+	declare -Ag _shwrap_modules_hashes=()
+	declare -Ag _shwrap_modules_names=()
+	declare -Ag _shwrap_modules_partials=()
+	declare -Ag _shwrap_modules_parts=()
+	declare -Ag _shwrap_modules_paths=()
+	declare -Ag _shwrap_scope=([.]=$(declare -px))
+	declare -ag _shwrap_modules_stack=()
+}

--- a/src/common.sh
+++ b/src/common.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # sh.wrap - module system for bash
+
 # common.sh
 # Common global, environment variables and function definitions for them.
 
@@ -16,6 +17,7 @@ declare -ax SHWRAP_MODULE_PATHS
 	declare -x SHWRAP_TMP_PATH="${_SHWRAP_TMP_PATH}"
 [[ -n "${SHWRAP_MODULE_PATHS[*]}" ]] ||
 	SHWRAP_MODULE_PATHS+=(.)
+[[ -d "${SHWRAP_TMP_PATH}" ]] || mkdir -p "${SHWRAP_TMP_PATH}"
 
 declare -ax _SHWRAP_FD_RANGE=(666 777)
 declare -x _SHWRAP_FD_RANDOM_MAXTRY=10
@@ -28,6 +30,7 @@ declare -x _SHWRAP_FD_FUNC=__shwrap_get_fd_sequential
 [[ -n "${SHWRAP_FD_FUNC}" ]] ||
 	SHWRAP_FD_FUNC="${_SHWRAP_FD_FUNC}"
 
+# global variables
 declare -A _shwrap_modules
 declare -A _shwrap_modules_deps
 declare -A _shwrap_modules_hashes
@@ -39,8 +42,8 @@ declare -A _shwrap_scope
 declare -a _shwrap_fds
 declare -a _shwrap_modules_stack
 
+# update global scope
 [[ -v _shwrap_scope[.] ]] || _shwrap_scope+=([.]=$(declare -px))
-[[ -d "${SHWRAP_TMP_PATH}" ]] || mkdir -p "${SHWRAP_TMP_PATH}"
 
 function __shwrap_clean()
 {

--- a/src/import.sh
+++ b/src/import.sh
@@ -26,7 +26,7 @@ function __shwrap_circular()
 function __shwrap_hash()
 {
 	local __shwrap_module="$1"
-	printf '%s' "${__shwrap_module}" | md5sum | cut -d $' ' -f1
+	printf '%s' "${__shwrap_module}" | __shwrap_md5sum
 }
 
 function shwrap_import()

--- a/src/import.sh
+++ b/src/import.sh
@@ -5,16 +5,16 @@
 
 function __shwrap_partial_name()
 {
-	local parts=("$@")
-	cat <(IFS=.; echo -n ."${parts[*]}")
+	local __shwrap_parts=("$@")
+	cat <(IFS=.; echo -n ."${__shwrap_parts[*]}")
 }
 
 function __shwrap_circular()
 {
-	local module_hash="$1"
+	local __shwrap_module_hash="$1"
 	local i=0
 	for i in "${!_shwrap_modules_stack[@]}"; do
-		if [[ "${module_hash}" == "${_shwrap_modules_stack[${i}]}" ]]; then
+		if [[ "${__shwrap_module_hash}" == "${_shwrap_modules_stack[${i}]}" ]]; then
 			echo "${i}"
 			return
 		fi
@@ -24,8 +24,8 @@ function __shwrap_circular()
 
 function __shwrap_hash()
 {
-	local module="$1"
-	printf '%s' "${module}" | md5sum | cut -d $' ' -f1
+	local __shwrap_module="$1"
+	printf '%s' "${__shwrap_module}" | md5sum | cut -d $' ' -f1
 }
 
 function shwrap_import()

--- a/src/import.sh
+++ b/src/import.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # sh.wrap - module system for bash
+
 # import.sh
 # Import related functions.
 
@@ -102,6 +103,7 @@ function __shwrap__import()
 				__shwrap_part="$(__shwrap_partial_name "${__shwrap_parts[@]}")"."${__shwrap_dep}"
 				if [[ $# == 0 ]]; then
 					# shellcheck disable=SC2207
+					# intentional use of word splitting
 					__shwrap_names=($(__shwrap_run "${__shwrap_part}" 'declare -Fx' | cut -d $' ' -f3))
 				fi
 				for __shwrap_name in "${__shwrap_names[@]}"; do
@@ -156,8 +158,8 @@ EOF
 			fi
 		done
 	fi
-	# fix partially imported wrappers and back propagate scope
 	if [[ "${__shwrap_i}" == -1 ]]; then
+		# fix partially imported wrappers
 		if [[ ! -v _shwrap_modules_partials["${__shwrap_module}"] ]]; then
 			if [[ $# != 0 ]]; then
 				local __shwrap_module_revdeps=()
@@ -183,7 +185,7 @@ EOF
 							_shwrap_modules_names+=(["${__shwrap_partial_hash}"]="${__shwrap_partial}")
 							_shwrap_modules_partials+=(["${__shwrap_partial}"]="")
 							# shellcheck disable=SC2016
-							# intentional use of single quotes to avoid expansion
+							# intentional use of single quotes to avoid unwanted expansions
 							local __shwrap_command='eval "$(__shwrap_run '"${_shwrap_modules_parts[${__shwrap_revdeps[@]}]}"' "declare -f '"${__shwrap_name}"'")"; declare -f'
 							_shwrap_modules["${__shwrap_partial_hash}"]="$(__shwrap_run "${__shwrap_partial}" "${__shwrap_command}")"
 							__shwrap_command="__shwrap__import '${__shwrap_partial}' '${__shwrap_module_hash}' '${__shwrap_revdeps[0]}' '${__shwrap_name}'; declare -f"

--- a/src/import.sh
+++ b/src/import.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+# sh.wrap - module system for bash
+# import.sh
+# Import related functions.
+
+function __shwrap_partial_name()
+{
+	local parts=("$@")
+	cat <(IFS=.; echo -n ."${parts[*]}")
+}
+
+function __shwrap_circular()
+{
+	local module_hash="$1"
+	local i=0
+	for i in "${!_shwrap_modules_stack[@]}"; do
+		if [[ "${module_hash}" == "${_shwrap_modules_stack[${i}]}" ]]; then
+			echo "${i}"
+			return
+		fi
+	done
+	echo -1
+}
+
+function __shwrap_hash()
+{
+	local module="$1"
+	printf '%s' "${module}" | md5sum | cut -d $' ' -f1
+}
+
+function shwrap_import()
+{
+	local __shwrap_module="$1"
+	shift
+
+	local __shwrap_names=("$@")
+	local __shwrap_module_hash __shwrap_module_path
+	__shwrap_module_path=$(__shwrap_search "${__shwrap_module}")
+	__shwrap_module_hash=$(__shwrap_hash "${__shwrap_module_path}")
+	__shwrap_import "${__shwrap_module_path}" "${__shwrap_module_hash}" "${__shwrap_names[@]}"
+}
+
+function __shwrap_import()
+{
+	local __shwrap_module="$1"
+	local __shwrap_scope="$2"
+	shift 2
+
+	local __shwrap_names=("$@")
+	local __shwrap_caller
+	if [[ "${#_shwrap_modules_stack[@]}" == 0 ]]; then
+		__shwrap_caller=.
+	else
+		__shwrap_caller="${_shwrap_modules_stack[-1]}"
+	fi
+	__shwrap__import "${__shwrap_module}" "${__shwrap_scope}" "${__shwrap_caller}" "${__shwrap_names[@]}"
+}
+
+function __shwrap__import()
+{
+	local __shwrap_module="$1"
+	local __shwrap_scope="$2"
+	local __shwrap_caller="$3"
+	shift 3
+
+	local __shwrap_name __shwrap_names=("$@")
+	local __shwrap_i
+	local __shwrap_module_hash __shwrap_module_path __shwrap_partial __shwrap_partial_hash
+	# import and cache partially imported modules
+	__shwrap_log "__shwrap__import: import '${__shwrap_module}' '${__shwrap_scope}' '${__shwrap_caller}'" >&2
+	if [[ ! -v _shwrap_modules_partials["${__shwrap_module}"] ]]; then
+		__shwrap_module_path=$(__shwrap_search "${__shwrap_module}")
+		__shwrap_module="${__shwrap_module_path}"
+		__shwrap_module_hash=$(__shwrap_hash "${__shwrap_module_path}")
+		_shwrap_modules_paths+=(["${__shwrap_module}"]="${__shwrap_module_path}")
+		_shwrap_modules_hashes+=(["${__shwrap_module}"]="${__shwrap_module_hash}")
+		_shwrap_modules_names+=(["${__shwrap_module_hash}"]="${__shwrap_module}")
+		__shwrap_log "__shwrap__import: hash '${__shwrap_module}' '${__shwrap_module_hash}'" >&2
+		if [[ "${#_shwrap_modules_stack[@]}" -gt 0 ]]; then
+			if [[ "${_shwrap_modules_stack[-1]}" == "${__shwrap_module_hash}" ]]; then
+				return 0
+			fi
+			__shwrap_partial=$(__shwrap_partial_name "${_shwrap_modules_stack[@]}")
+			__shwrap_partial="${__shwrap_partial}"."${__shwrap_module_hash}"
+			__shwrap_partial_hash=$(__shwrap_hash "${__shwrap_partial}")
+			__shwrap_log "__shwrap__import: hash '${__shwrap_partial}' '${__shwrap_partial_hash}'" >&2
+			# create partial definitions and scope
+			if [[ ! -v _shwrap_modules["${__shwrap_partial_hash}"] ]]; then
+				_shwrap_modules+=(["${__shwrap_partial_hash}"]=$(declare -f))
+				_shwrap_modules_hashes+=(["${__shwrap_partial}"]="${__shwrap_partial_hash}")
+				_shwrap_modules_names+=(["${__shwrap_partial_hash}"]="${__shwrap_partial}")
+				_shwrap_modules_partials+=(["${__shwrap_partial}"]="")
+				_shwrap_scope+=(["${_shwrap_modules_stack[-1]}"]=$(__shwrap_scope))
+			fi
+		fi
+		# handle circular dependency
+		__shwrap_i=$(__shwrap_circular "${__shwrap_module_hash}")
+		if [[ "${__shwrap_i}" != -1 ]]; then
+			if [[ "${_shwrap_modules[${__shwrap_module_hash}]}" == "###INITIALIZE MODULE###;" ]]; then
+				local __shwrap_parts=("${_shwrap_modules_stack[@]:0:$((++__shwrap_i))}")
+				local __shwrap_part __shwrap_dep="${_shwrap_modules_stack[${__shwrap_i}]}"
+				__shwrap_part="$(__shwrap_partial_name "${__shwrap_parts[@]}")"."${__shwrap_dep}"
+				if [[ $# == 0 ]]; then
+					# shellcheck disable=SC2207
+					__shwrap_names=($(__shwrap_run "${__shwrap_part}" 'declare -Fx' | cut -d $' ' -f3))
+				fi
+				for __shwrap_name in "${__shwrap_names[@]}"; do
+					if __shwrap_run "${__shwrap_part}" '__shwrap_name_is_function '"${__shwrap_name}"; then
+						__shwrap_log "__shwrap__import: import name '${__shwrap_part}' '${__shwrap_module}' '${__shwrap_name}'" >&2
+						__shwrap_import "${__shwrap_part}" "${__shwrap_module_hash}" "${__shwrap_name}"
+						_shwrap_modules_deps["${_shwrap_modules_stack[@]: -1}" "${__shwrap_module_hash}"]+="${__shwrap_name} "
+						_shwrap_modules_parts["${_shwrap_modules_stack[@]: -1}" "${__shwrap_module_hash}"]="${__shwrap_part}"
+					else
+						__shwrap_log "__shwrap__import: error: '${__shwrap_name}' not imported from module '${__shwrap_module}'" >&2
+					fi
+				done
+				return 0
+			fi
+		else
+			_shwrap_modules_stack+=("${__shwrap_module_hash}")
+		fi
+	fi
+	# import module exports
+	if [[ $# == 0 ]]; then
+		# cache module to avoid infinite recursion
+		__shwrap__run "${__shwrap_module}" "${__shwrap_scope}" "###IMPORT###"
+		# shellcheck disable=SC2207
+		__shwrap_names=($(__shwrap_run "${__shwrap_module}" 'declare -Fx' | cut -d $' ' -f3))
+		if [[ "${__shwrap_i}" == -1 ]]; then # prepare imports stack
+			unset '_shwrap_modules_stack[-1]'
+		fi
+		if [[ -n "${__shwrap_names[*]}" ]]; then
+			__shwrap_log "__shwrap__import: import names '${__shwrap_module}' '${__shwrap_scope}' '${__shwrap_names[*]}'" >&2
+			__shwrap_import "${__shwrap_module}" "${__shwrap_scope}" "${__shwrap_names[@]}"
+		fi
+		if [[ "${__shwrap_i}" == -1 ]]; then # restore imports stack
+			_shwrap_modules_stack+=("${__shwrap_module_hash}")
+		fi
+	else
+		for __shwrap_name in "${__shwrap_names[@]}"; do
+			# wrap module name
+			if __shwrap_run "${__shwrap_module}" '__shwrap_name_is_function '"${__shwrap_name}"; then
+				# shellcheck disable=SC1090
+				source <(cat <<EOF
+function ${__shwrap_name}() {
+	# update caller scope before run
+	_shwrap_scope+=([${__shwrap_caller}]=\$(__shwrap_scope))
+	__shwrap__run "${__shwrap_module}" "${__shwrap_scope}" "${__shwrap_name}" "\$@"
+	# apply caller scope after run
+	eval "\${_shwrap_scope[${__shwrap_caller}]}"
+}
+EOF
+						)
+			else
+				echo module: "'${__shwrap_name}' not imported from module '${__shwrap_module}'" >&2
+			fi
+		done
+	fi
+	# fix partially imported wrappers and back propagate scope
+	if [[ "${__shwrap_i}" == -1 ]]; then
+		if [[ ! -v _shwrap_modules_partials["${__shwrap_module}"] ]]; then
+			if [[ $# != 0 ]]; then
+				local __shwrap_module_revdeps=()
+				readarray -t -d $'\n' __shwrap_module_revdeps < <(printf '%s\n' "${!_shwrap_modules_deps[@]}" | grep "${__shwrap_module_hash}$")
+				for __shwrap_module_revdep in "${__shwrap_module_revdeps[@]}"; do
+					# shellcheck disable=SC2206
+					# intentional use of word splitting
+					local __shwrap_revdeps=(${__shwrap_module_revdep})
+					# shellcheck disable=SC2086
+					# intentional use of word splitting
+					_shwrap_modules_deps["${__shwrap_revdeps[@]}"]=$(printf '%s\n' ${_shwrap_modules_deps["${__shwrap_revdeps[@]}"]} | sort | uniq | xargs)
+					__shwrap_log "__shwrap__import: fix '${__shwrap_revdeps[*]}'" >&2
+					if [[ "${__shwrap_module_hash}" == "${__shwrap_revdeps[1]}" ]]; then
+						# shellcheck disable=SC2206
+						# intentional use of word splitting
+						__shwrap_names=(${_shwrap_modules_deps["${__shwrap_revdeps[@]}"]})
+						_shwrap_modules_deps["${__shwrap_revdeps[@]}"]=""
+						for __shwrap_name in "${__shwrap_names[@]}"; do
+							__shwrap_partial="${_shwrap_modules_parts[${__shwrap_revdeps[@]}]}"-"${__shwrap_revdeps[0]}"
+							__shwrap_partial_hash=$(__shwrap_hash "${__shwrap_partial}")
+							_shwrap_modules+=(["${__shwrap_partial_hash}"]="${_shwrap_modules[${__shwrap_module_hash}]}")
+							_shwrap_modules_hashes+=(["${__shwrap_partial}"]="${__shwrap_partial_hash}")
+							_shwrap_modules_names+=(["${__shwrap_partial_hash}"]="${__shwrap_partial}")
+							_shwrap_modules_partials+=(["${__shwrap_partial}"]="")
+							# shellcheck disable=SC2016
+							# intentional use of single quotes to avoid expansion
+							local __shwrap_command='eval "$(__shwrap_run '"${_shwrap_modules_parts[${__shwrap_revdeps[@]}]}"' "declare -f '"${__shwrap_name}"'")"; declare -f'
+							_shwrap_modules["${__shwrap_partial_hash}"]="$(__shwrap_run "${__shwrap_partial}" "${__shwrap_command}")"
+							__shwrap_command="__shwrap__import '${__shwrap_partial}' '${__shwrap_module_hash}' '${__shwrap_revdeps[0]}' '${__shwrap_name}'; declare -f"
+							_shwrap_modules+=(["${__shwrap_revdeps[0]}"]=$(__shwrap_run "${_shwrap_modules_names[${__shwrap_revdeps[0]}]}" "${__shwrap_command}"))
+						done
+					fi
+				done
+			fi
+		fi
+		unset '_shwrap_modules_stack[-1]'
+		if [[ "${#_shwrap_modules_stack[@]}" -gt 0 ]]; then
+			# apply scope changes after import
+			eval "$(printf '%s' "${_shwrap_scope[${_shwrap_modules_stack[-1]}]}" | __shwrap_declare)"
+		fi
+	fi
+}

--- a/src/import.sh
+++ b/src/import.sh
@@ -67,9 +67,9 @@ function __shwrap__import()
 	local __shwrap_name __shwrap_names=("$@")
 	local __shwrap_i
 	local __shwrap_module_hash __shwrap_module_path __shwrap_partial __shwrap_partial_hash
-	# import and cache partially imported modules
 	__shwrap_log "__shwrap__import: import '${__shwrap_module}' '${__shwrap_scope}' '${__shwrap_caller}'" >&2
 	if [[ ! -v _shwrap_modules_partials["${__shwrap_module}"] ]]; then
+		# import and cache partially imported modules
 		__shwrap_module_path=$(__shwrap_search "${__shwrap_module}")
 		__shwrap_module="${__shwrap_module_path}"
 		__shwrap_module_hash=$(__shwrap_hash "${__shwrap_module_path}")
@@ -85,8 +85,8 @@ function __shwrap__import()
 			__shwrap_partial="${__shwrap_partial}"."${__shwrap_module_hash}"
 			__shwrap_partial_hash=$(__shwrap_hash "${__shwrap_partial}")
 			__shwrap_log "__shwrap__import: hash '${__shwrap_partial}' '${__shwrap_partial_hash}'" >&2
-			# create partial definitions and scope
 			if [[ ! -v _shwrap_modules["${__shwrap_partial_hash}"] ]]; then
+				# create partial definitions and scope
 				_shwrap_modules+=(["${__shwrap_partial_hash}"]=$(declare -f))
 				_shwrap_modules_hashes+=(["${__shwrap_partial}"]="${__shwrap_partial_hash}")
 				_shwrap_modules_names+=(["${__shwrap_partial_hash}"]="${__shwrap_partial}")
@@ -94,9 +94,9 @@ function __shwrap__import()
 				_shwrap_scope+=(["${_shwrap_modules_stack[-1]}"]=$(__shwrap_scope))
 			fi
 		fi
-		# handle circular dependency
 		__shwrap_i=$(__shwrap_circular "${__shwrap_module_hash}")
 		if [[ "${__shwrap_i}" != -1 ]]; then
+			# handle circular dependency
 			if [[ "${_shwrap_modules[${__shwrap_module_hash}]}" == "###INITIALIZE MODULE###;" ]]; then
 				local __shwrap_parts=("${_shwrap_modules_stack[@]:0:$((++__shwrap_i))}")
 				local __shwrap_part __shwrap_dep="${_shwrap_modules_stack[${__shwrap_i}]}"
@@ -122,11 +122,12 @@ function __shwrap__import()
 			_shwrap_modules_stack+=("${__shwrap_module_hash}")
 		fi
 	fi
-	# import module exports
 	if [[ $# == 0 ]]; then
+		# import module exports
 		# cache module to avoid infinite recursion
 		__shwrap__run "${__shwrap_module}" "${__shwrap_scope}" "###IMPORT###"
 		# shellcheck disable=SC2207
+		# intentional use of word splitting
 		__shwrap_names=($(__shwrap_run "${__shwrap_module}" 'declare -Fx' | cut -d $' ' -f3))
 		if [[ "${__shwrap_i}" == -1 ]]; then # prepare imports stack
 			unset '_shwrap_modules_stack[-1]'
@@ -140,9 +141,10 @@ function __shwrap__import()
 		fi
 	else
 		for __shwrap_name in "${__shwrap_names[@]}"; do
-			# wrap module name
 			if __shwrap_run "${__shwrap_module}" '__shwrap_name_is_function '"${__shwrap_name}"; then
+				# wrap module name
 				# shellcheck disable=SC1090
+				# source from string
 				source <(cat <<EOF
 function ${__shwrap_name}() {
 	# update caller scope before run

--- a/src/init.sh
+++ b/src/init.sh
@@ -7,6 +7,7 @@
 [[ -n "${SHWRAP_INIT_DIR}" ]] || SHWRAP_INIT_DIR="${BASH_SOURCE[0]}"
 declare -x SHWRAP_INIT_DIR
 
+# shellcheck source=src/common.sh
 source "${SHWRAP_INIT_DIR}"/module.sh
 
 shwrap_import sh.wrap/module.sh

--- a/src/init.sh
+++ b/src/init.sh
@@ -3,6 +3,9 @@
 # init.sh
 # Initialization script intended to be in user shell profile.
 
-source module.sh
+[[ -n "${SHWRAP_INIT_DIR}" ]] || SHWRAP_INIT_DIR="${BASH_SOURCE[0]}"
+declare -x SHWRAP_INIT_DIR
+
+source "${SHWRAP_INIT_DIR}"/module.sh
 
 shwrap_import sh.wrap/module.sh

--- a/src/init.sh
+++ b/src/init.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # sh.wrap - module system for bash
+
 # init.sh
 # Initialization script intended to be in user shell profile.
 

--- a/src/init.sh
+++ b/src/init.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# sh.wrap - module system for bash
+# init.sh
+# Initialization script intended to be in user shell profile.
+
+source module.sh
+
+shwrap_import sh.wrap/module.sh

--- a/src/module.sh
+++ b/src/module.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # sh.wrap - module system for bash
+
 # module.sh
 # Core of sh.wrap module system.
 

--- a/src/module.sh
+++ b/src/module.sh
@@ -4,8 +4,13 @@
 # module.sh
 # Core of sh.wrap module system.
 
+# shellcheck source=src/util.sh
 source "${SHWRAP_INIT_DIR}"/util.sh
+# shellcheck source=src/common.sh
 source "${SHWRAP_INIT_DIR}"/common.sh
+# shellcheck source=src/import.sh
 source "${SHWRAP_INIT_DIR}"/import.sh
+# shellcheck source=src/run.sh
 source "${SHWRAP_INIT_DIR}"/run.sh
+# shellcheck source=src/search.sh
 source "${SHWRAP_INIT_DIR}"/search.sh

--- a/src/module.sh
+++ b/src/module.sh
@@ -3,8 +3,8 @@
 # module.sh
 # Core of sh.wrap module system.
 
-source common.sh
-source import.sh
-source run.sh
-source search.sh
-source util.sh
+source "${SHWRAP_INIT_DIR}"/util.sh
+source "${SHWRAP_INIT_DIR}"/common.sh
+source "${SHWRAP_INIT_DIR}"/import.sh
+source "${SHWRAP_INIT_DIR}"/run.sh
+source "${SHWRAP_INIT_DIR}"/search.sh

--- a/src/module.sh
+++ b/src/module.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# sh.wrap - module system for bash
+# module.sh
+# Core of sh.wrap module system.
+
+source common.sh
+source import.sh
+source run.sh
+source search.sh
+source util.sh

--- a/src/run.sh
+++ b/src/run.sh
@@ -35,6 +35,7 @@ function __shwrap__run()
 	local command_string="$3"
 	shift 3
 
+	local __shwrap_ret=1
 	local command __shwrap_module_hash
 	local fd_scope fd_scope_cap fd_out fd_out_cap
 	__shwrap_module_hash="${_shwrap_modules_hashes[${__shwrap_module_path}]}"
@@ -81,8 +82,8 @@ function __shwrap__run()
 			declare -p _shwrap_scope;
 			declare -p _shwrap_fds;
 			declare -p _shwrap_modules_stack;
-			declare -p __shwrap_ret;
 		} | __shwrap_declare >&'"${fd_scope}"'
+		declare -p __shwrap_ret >&'"${fd_scope}"'
 		exit ${__shwrap_ret}'
 	{
 		eval "exec ${fd_out}>&1"
@@ -120,6 +121,7 @@ function __shwrap_cache()
 	local __shwrap_module_path="$1"
 	local scope="$2"
 
+	local __shwrap_ret=1
 	local command __shwrap_module_hash
 	local fd_scope fd_scope_cap fd_out fd_out_cap
 	__shwrap_module_hash="${_shwrap_modules_hashes[${__shwrap_module_path}]}"
@@ -162,9 +164,9 @@ function __shwrap_cache()
 			declare -p _shwrap_scope;
 			declare -p _shwrap_fds;
 			declare -p _shwrap_modules_stack;
-			declare -p __shwrap_ret;
 		} | __shwrap_declare >&'"${fd_scope}"'
-		exit ${ret}'
+		declare -p __shwrap_ret >&'"${fd_scope}"'
+		exit ${__shwrap_ret}'
 	{
 		eval "exec ${fd_out}>&1"
 		exec {fd_scope_cap}< <(

--- a/src/run.sh
+++ b/src/run.sh
@@ -41,8 +41,13 @@ function __shwrap__run()
 		_shwrap_modules+=(["${module_hash}"]="###INITIALIZE MODULE###;")
 		__shwrap_cache "${module_path}" "${scope}"
 	}
-	exec {fd_scope}</dev/null
-	exec {fd_out}</dev/null
+	fd_scope=$(__shwrap_get_fd "${SHWRAP_FD_RANGE[@]}")
+	eval "exec ${fd_scope}< /dev/null"
+	_shwrap_fds["${fd_scope}"]="${fd_scope}"
+	fd_out=$(__shwrap_get_fd "${SHWRAP_FD_RANGE[@]}")
+	eval "exec ${fd_out}< /dev/null"
+	_shwrap_fds["${fd_out}"]="${fd_out}"
+	__shwrap_log "__shwrap__run: fds ${_shwrap_fds[*]}" >&2
 	# shellcheck disable=SC2016
 	# intentional use of single quotes to avoid unwanted expansions
 	command='${_MODULE_DEBUG:+set -x}
@@ -54,6 +59,7 @@ function __shwrap__run()
 		'"$(declare -p _shwrap_modules_parts)"'
 		'"$(declare -p _shwrap_modules_paths)"'
 		'"$(declare -p _shwrap_scope)"'
+		'"$(declare -p _shwrap_fds)"'
 		'"$(declare -p _shwrap_modules_stack)"'
 		eval "${_shwrap_scope[.]}"
 		source '"${SHWRAP_MODULE}"'
@@ -71,6 +77,7 @@ function __shwrap__run()
 			declare -p _shwrap_modules_parts;
 			declare -p _shwrap_modules_paths;
 			declare -p _shwrap_scope;
+			declare -p _shwrap_fds;
 			declare -p _shwrap_modules_stack;
 			declare -p __shwrap_ret;
 		} | __shwrap_declare >&'"${fd_scope}"'
@@ -99,8 +106,10 @@ function __shwrap__run()
 		exec {fd_scope_cap}<&-
 		eval "exec ${fd_out}>&-"
 	}
-	exec {fd_scope}<&-
-	exec {fd_out}<&-
+	eval "exec {fd_scope}<&-"
+	eval "exec {fd_out}<&-"
+	unset '_shwrap_fds["${fd_scope}"]'
+	unset '_shwrap_fds["${fd_out}"]'
 
 	# shellcheck disable=SC2154
 	return "${__shwrap_ret}"
@@ -116,8 +125,13 @@ function __shwrap_cache()
 	module_hash="${_shwrap_modules_hashes[${module_path}]}"
 	local command module_hash
 	__shwrap_log "__shwrap_cache: cache '${module_path}' '${scope}'" >&2
-	exec {fd_scope}</dev/null
-	exec {fd_out}</dev/null
+	fd_scope=$(__shwrap_get_fd "${SHWRAP_FD_RANGE[@]}")
+	eval "exec ${fd_scope}< /dev/null"
+	_shwrap_fds["${fd_scope}"]="${fd_scope}"
+	fd_out=$(__shwrap_get_fd "${SHWRAP_FD_RANGE[@]}")
+	eval "exec ${fd_out}< /dev/null"
+	_shwrap_fds["${fd_out}"]="${fd_out}"
+	__shwrap_log "__shwrap__run: fds ${_shwrap_fds[*]}" >&2
 	# shellcheck disable=SC2016
 	# intentional use of single quotes to avoid unwanted expansions
 	command='${_MODULE_DEBUG:+set -x}
@@ -129,6 +143,7 @@ function __shwrap_cache()
 		'"$(declare -p _shwrap_modules_parts)"'
 		'"$(declare -p _shwrap_modules_paths)"'
 		'"$(declare -p _shwrap_scope)"'
+		'"$(declare -p _shwrap_fds)"'
 		'"$(declare -p _shwrap_modules_stack)"'
 		eval "${_shwrap_scope[.]}"
 		source '"${SHWRAP_MODULE}"'
@@ -145,6 +160,7 @@ function __shwrap_cache()
 			declare -p _shwrap_modules_parts;
 			declare -p _shwrap_modules_paths;
 			declare -p _shwrap_scope;
+			declare -p _shwrap_fds;
 			declare -p _shwrap_modules_stack;
 			declare -p __shwrap_ret;
 		} | __shwrap_declare >&'"${fd_scope}"'
@@ -173,8 +189,10 @@ function __shwrap_cache()
 		exec {fd_scope_cap}<&-
 		eval "exec ${fd_out}>&-"
 	}
-	exec {fd_scope}<&-
-	exec {fd_out}<&-
+	eval "exec {fd_scope}<&-"
+	eval "exec {fd_out}<&-"
+	unset '_shwrap_fds["${fd_scope}"]'
+	unset '_shwrap_fds["${fd_out}"]'
 
 	# shellcheck disable=SC2154
 	return "${__shwrap_ret}"

--- a/src/run.sh
+++ b/src/run.sh
@@ -4,6 +4,7 @@
 # run.sh
 # Module runner and cache functions.
 
+# shellcheck source=src/common.sh
 source "${SHWRAP_INIT_DIR}"/common.sh
 
 function shwrap_run()

--- a/src/run.sh
+++ b/src/run.sh
@@ -90,12 +90,12 @@ function __shwrap__run()
 				{
 					eval "exec ${fd_scope}>&1 1>&${fd_out}"
 					cat <<< "${command}" \
-						> "${SHWRAP_TMP_PATH}"/"${__shwrap_module_hash}"_run.sh
+						> "${SHWRAP_TMP_PATH}"/"${SHWRAP_ID}"_"${__shwrap_module_hash}"_run.sh
 					env -i ${SHWRAP_MODULE_VERBOSE:+-v} \
 						SHWRAP_MODULE_DEBUG="${SHWRAP_MODULE_DEBUG}" \
 						SHWRAP_MODULE_LOG="${SHWRAP_MODULE_LOG}" \
 						"${SHELL}" --noprofile --norc \
-						"${SHWRAP_TMP_PATH}"/"${__shwrap_module_hash}"_run.sh "$@"
+						"${SHWRAP_TMP_PATH}"/"${SHWRAP_ID}"_"${__shwrap_module_hash}"_run.sh "$@"
 					eval "exec ${fd_scope}>&-"
 				}
 			)
@@ -172,12 +172,12 @@ function __shwrap_cache()
 				{
 					eval "exec ${fd_scope}>&1 1>&${fd_out}"
 					cat <<< "${command}" \
-						> "${SHWRAP_TMP_PATH}"/"${__shwrap_module_hash}"_cache.sh
+						> "${SHWRAP_TMP_PATH}"/"${SHWRAP_ID}"_"${__shwrap_module_hash}"_cache.sh
 					env -i ${SHWRAP_MODULE_VERBOSE:+-v} \
 						SHWRAP_MODULE_DEBUG="${SHWRAP_MODULE_DEBUG}" \
 						SHWRAP_MODULE_LOG="${SHWRAP_MODULE_LOG}" \
 						"${SHELL}" --noprofile --norc \
-						"${SHWRAP_TMP_PATH}"/"${__shwrap_module_hash}"_cache.sh
+						"${SHWRAP_TMP_PATH}"/"${SHWRAP_ID}"_"${__shwrap_module_hash}"_cache.sh
 					eval "exec ${fd_out}>&-"
 				}
 			)

--- a/src/run.sh
+++ b/src/run.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+# sh.wrap - module system for bash
+# run.sh
+# Module runner and cache functions.
+
+source common.sh
+
+function shwrap_run()
+{
+	local module="$1"
+	local command_string="$2"
+	shift 2
+
+	local module_path
+	module_path=$(__shwrap_search "${module}")
+	__shwrap_run "${module_path}" "${command_string}" "$@"
+}
+
+function __shwrap_run()
+{
+	local module_path="$1"
+	local command_string="$2"
+	shift 2
+
+	local module_hash
+	module_hash="${_shwrap_modules_hashes[${module_path}]}"
+	__shwrap__run "${module_path}" "${module_hash}" "${command_string}" "$@"
+}
+
+function __shwrap__run()
+{
+	local module_path="$1"
+	local scope="$2"
+	local command_string="$3"
+	shift 3
+
+	local command module_hash
+	local fd_scope fd_scope_cap fd_out fd_out_cap
+	module_hash="${_shwrap_modules_hashes[${module_path}]}"
+	[[ -v _shwrap_modules["${module_hash}"] ]] || {
+		_shwrap_modules+=(["${module_hash}"]="###INITIALIZE MODULE###;")
+		__shwrap_cache "${module_path}" "${scope}"
+	}
+	exec {fd_scope}</dev/null
+	exec {fd_out}</dev/null
+	# shellcheck disable=SC2016
+	# intentional use of single quotes to avoid unwanted expansions
+	command='${_MODULE_DEBUG:+set -x}
+		source '"${SHWRAP_MODULE}"'
+		'"$(declare -p _shwrap_modules)"'
+		'"$(declare -p _shwrap_modules_deps)"'
+		'"$(declare -p _shwrap_modules_hashes)"'
+		'"$(declare -p _shwrap_modules_names)"'
+		'"$(declare -p _shwrap_modules_partials)"'
+		'"$(declare -p _shwrap_modules_parts)"'
+		'"$(declare -p _shwrap_modules_paths)"'
+		'"$(declare -p _shwrap_scope)"'
+		'"$(declare -p _shwrap_modules_stack)"'
+		source /dev/stdin <<< "${_shwrap_modules['"${module_hash}"']}"
+		eval "${_shwrap_scope[.]}"
+		eval "${_shwrap_scope['"${scope}"']}"
+		'"${command_string}"' "$@"
+		declare __shwrap_ret=$?
+		_shwrap_scope+=(['"${scope}"']=$(__shwrap_scope))
+		{
+			declare -p _shwrap_modules;
+			declare -p _shwrap_modules_deps;
+			declare -p _shwrap_modules_hashes;
+			declare -p _shwrap_modules_names;
+			declare -p _shwrap_modules_partials;
+			declare -p _shwrap_modules_parts;
+			declare -p _shwrap_modules_paths;
+			declare -p _shwrap_scope;
+			declare -p _shwrap_modules_stack;
+			declare -p __shwrap_ret;
+		} | __shwrap_declare >&'"${fd_scope}"'
+		exit ${__shwrap_ret}'
+	{
+		eval "exec ${fd_out}>&1"
+		exec {fd_scope_cap}< <(
+			exec {fd_out_cap}< <(
+				{
+					eval "exec ${fd_scope}>&1 1>&${fd_out}"
+					cat <<< "${command}" \
+						> "${SHWRAP_TMP_PATH}"/"${module_hash}"_run.sh
+					env -i ${_MODULE_VERBOSE:+-v} \
+						_MODULE_DEBUG="${_MODULE_DEBUG}" \
+						_MODULE_LOG="${_MODULE_LOG}" \
+						"${SHELL}" --noprofile --norc \
+						"${SHWRAP_TMP_PATH}"/"${module_hash}"_run.sh "$@"
+					eval "exec ${fd_scope}>&-"
+				}
+			)
+			cat <&"${fd_out_cap}"
+			exec {fd_out_cap}<&-
+		)
+		# shellcheck disable=SC2046
+		eval "$(cat <&"${fd_scope_cap}")"
+		exec {fd_scope_cap}<&-
+		eval "exec ${fd_out}>&-"
+	}
+	exec {fd_scope}<&-
+	exec {fd_out}<&-
+
+	# shellcheck disable=SC2154
+	return "${__shwrap_ret}"
+}
+
+function __shwrap_cache()
+{
+	local module_path="$1"
+	local scope="$2"
+
+	local command module_hash
+	local fd_scope fd_scope_cap fd_out fd_out_cap
+	module_hash="${_shwrap_modules_hashes[${module_path}]}"
+	local command module_hash
+	__shwrap_log "__shwrap_cache: cache '${module_path}' '${scope}'" >&2
+	exec {fd_scope}</dev/null
+	exec {fd_out}</dev/null
+	# shellcheck disable=SC2016
+	# intentional use of single quotes to avoid unwanted expansions
+	command='${_MODULE_DEBUG:+set -x}
+		source '"${SHWRAP_MODULE}"'
+		'"$(declare -p _shwrap_modules)"'
+		'"$(declare -p _shwrap_modules_deps)"'
+		'"$(declare -p _shwrap_modules_hashes)"'
+		'"$(declare -p _shwrap_modules_names)"'
+		'"$(declare -p _shwrap_modules_partials)"'
+		'"$(declare -p _shwrap_modules_parts)"'
+		'"$(declare -p _shwrap_modules_paths)"'
+		'"$(declare -p _shwrap_scope)"'
+		'"$(declare -p _shwrap_modules_stack)"'
+		eval "${_shwrap_scope[.]}"
+		source '"${module_path}"'
+		declare __shwrap_ret=$?
+		_shwrap_modules+=(['"${module_hash}"']=$(declare -f))
+		_shwrap_scope+=(['"${scope}"']=$(__shwrap_scope))
+		{
+			declare -p _shwrap_modules;
+			declare -p _shwrap_modules_deps;
+			declare -p _shwrap_modules_hashes;
+			declare -p _shwrap_modules_names;
+			declare -p _shwrap_modules_partials;
+			declare -p _shwrap_modules_parts;
+			declare -p _shwrap_modules_paths;
+			declare -p _shwrap_scope;
+			declare -p _shwrap_modules_stack;
+			declare -p __shwrap_ret;
+		} | __shwrap_declare >&'"${fd_scope}"'
+		exit ${ret}'
+	{
+		eval "exec ${fd_out}>&1"
+		exec {fd_scope_cap}< <(
+			exec {fd_out_cap}< <(
+				{
+					eval "exec ${fd_scope}>&1 1>&${fd_out}"
+					cat <<< "${command}" \
+						> "${SHWRAP_TMP_PATH}"/"${module_hash}"_cache.sh
+					env -i ${_MODULE_VERBOSE:+-v} \
+						_MODULE_DEBUG="${_MODULE_DEBUG}" \
+						_MODULE_LOG="${_MODULE_LOG}" \
+						"${SHELL}" --noprofile --norc \
+						"${SHWRAP_TMP_PATH}"/"${module_hash}"_cache.sh
+					eval "exec ${fd_out}>&-"
+				}
+			)
+			cat <&"${fd_out_cap}"
+			exec {fd_out_cap}<&-
+		)
+		# shellcheck disable=SC2046
+		eval "$(cat <&"${fd_scope_cap}")"
+		exec {fd_scope_cap}<&-
+		eval "exec ${fd_out}>&-"
+	}
+	exec {fd_scope}<&-
+	exec {fd_out}<&-
+
+	# shellcheck disable=SC2154
+	return "${__shwrap_ret}"
+}

--- a/src/run.sh
+++ b/src/run.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # sh.wrap - module system for bash
+
 # run.sh
 # Module runner and cache functions.
 

--- a/src/run.sh
+++ b/src/run.sh
@@ -49,6 +49,7 @@ function __shwrap__run()
 	eval "exec ${fd_out}< /dev/null"
 	_shwrap_fds["${fd_out}"]="${fd_out}"
 	__shwrap_log "__shwrap__run: fds ${_shwrap_fds[*]}" >&2
+
 	# shellcheck disable=SC2016
 	# intentional use of single quotes to avoid unwanted expansions
 	command='${SHWRAP_MODULE_DEBUG:+set -x}
@@ -102,7 +103,6 @@ function __shwrap__run()
 			cat <&"${fd_out_cap}"
 			exec {fd_out_cap}<&-
 		)
-		# shellcheck disable=SC2046
 		eval "$(cat <&"${fd_scope_cap}")"
 		exec {fd_scope_cap}<&-
 		eval "exec ${fd_out}>&-"
@@ -112,7 +112,6 @@ function __shwrap__run()
 	unset '_shwrap_fds["${fd_scope}"]'
 	unset '_shwrap_fds["${fd_out}"]'
 
-	# shellcheck disable=SC2154
 	return "${__shwrap_ret}"
 }
 
@@ -132,6 +131,7 @@ function __shwrap_cache()
 	eval "exec ${fd_out}< /dev/null"
 	_shwrap_fds["${fd_out}"]="${fd_out}"
 	__shwrap_log "__shwrap__run: fds ${_shwrap_fds[*]}" >&2
+
 	# shellcheck disable=SC2016
 	# intentional use of single quotes to avoid unwanted expansions
 	command='${SHWRAP_MODULE_DEBUG:+set -x}
@@ -184,7 +184,6 @@ function __shwrap_cache()
 			cat <&"${fd_out_cap}"
 			exec {fd_out_cap}<&-
 		)
-		# shellcheck disable=SC2046
 		eval "$(cat <&"${fd_scope_cap}")"
 		exec {fd_scope_cap}<&-
 		eval "exec ${fd_out}>&-"
@@ -194,6 +193,5 @@ function __shwrap_cache()
 	unset '_shwrap_fds["${fd_scope}"]'
 	unset '_shwrap_fds["${fd_out}"]'
 
-	# shellcheck disable=SC2154
 	return "${__shwrap_ret}"
 }

--- a/src/run.sh
+++ b/src/run.sh
@@ -3,7 +3,7 @@
 # run.sh
 # Module runner and cache functions.
 
-source common.sh
+source "${SHWRAP_INIT_DIR}"/common.sh
 
 function shwrap_run()
 {
@@ -46,7 +46,6 @@ function __shwrap__run()
 	# shellcheck disable=SC2016
 	# intentional use of single quotes to avoid unwanted expansions
 	command='${_MODULE_DEBUG:+set -x}
-		source '"${SHWRAP_MODULE}"'
 		'"$(declare -p _shwrap_modules)"'
 		'"$(declare -p _shwrap_modules_deps)"'
 		'"$(declare -p _shwrap_modules_hashes)"'
@@ -56,8 +55,9 @@ function __shwrap__run()
 		'"$(declare -p _shwrap_modules_paths)"'
 		'"$(declare -p _shwrap_scope)"'
 		'"$(declare -p _shwrap_modules_stack)"'
-		source /dev/stdin <<< "${_shwrap_modules['"${module_hash}"']}"
 		eval "${_shwrap_scope[.]}"
+		source '"${SHWRAP_MODULE}"'
+		source /dev/stdin <<< "${_shwrap_modules['"${module_hash}"']}"
 		eval "${_shwrap_scope['"${scope}"']}"
 		'"${command_string}"' "$@"
 		declare __shwrap_ret=$?
@@ -121,7 +121,6 @@ function __shwrap_cache()
 	# shellcheck disable=SC2016
 	# intentional use of single quotes to avoid unwanted expansions
 	command='${_MODULE_DEBUG:+set -x}
-		source '"${SHWRAP_MODULE}"'
 		'"$(declare -p _shwrap_modules)"'
 		'"$(declare -p _shwrap_modules_deps)"'
 		'"$(declare -p _shwrap_modules_hashes)"'
@@ -132,6 +131,7 @@ function __shwrap_cache()
 		'"$(declare -p _shwrap_scope)"'
 		'"$(declare -p _shwrap_modules_stack)"'
 		eval "${_shwrap_scope[.]}"
+		source '"${SHWRAP_MODULE}"'
 		source '"${module_path}"'
 		declare __shwrap_ret=$?
 		_shwrap_modules+=(['"${module_hash}"']=$(declare -f))

--- a/src/search.sh
+++ b/src/search.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# sh.wrap - module system for bash
+# search.sh
+# Module search functions.
+
+source common.sh
+
+function __shwrap_path()
+{
+	local module="$1"
+	realpath -qsm "${module}"
+}
+
+function __shwrap_search()
+{
+	local module="$1"
+	local module_dir module_hash module_name module_path
+	module_path=$(__shwrap_path "${module}")
+	__shwrap_log "__shwrap_search: search '${module}'" >&2
+	# check absolute path
+	if [[ "${module}" == "${module_path}" ]]; then
+		printf '%s' "${module_path}"
+		return 0
+	fi
+	# check relative path
+	if [[ "${#_shwrap_modules_stack[@]}" -gt 0 ]]; then
+		module_hash="${_shwrap_modules_stack[-1]}"
+		module_name="${_shwrap_modules_names[${module_hash}]}"
+		module_path="${_shwrap_modules_paths[${module_name}]}"
+		module_dir=$(dirname "${module_path}")
+		if realpath -qse "${module_dir}"/"${module}"; then
+			return 0
+		fi
+	fi
+	# check user paths
+	if [[ "${module}" == "${module#./*}" ]] &&
+		   [[ "${module}" == "${module#../*}" ]]; then
+		for module_dir in "${SHWRAP_MODULE_PATHS[@]}"; do
+			local path="${module_dir}"/"${module}"
+			if [[ "${module_dir}" == "${module_dir#/*}" ]]; then
+				if [[ "${#_shwrap_modules_stack[@]}" -gt 0 ]]; then
+					module_hash="${_shwrap_modules_stack[-1]}"
+					module_name="${_shwrap_modules_names[${module_hash}]}"
+					module_path="${_shwrap_modules_paths[${module_name}]}"
+					path=$(dirname "${module_path}")/"${module_dir}"/"${module}"
+				fi
+			fi
+			if realpath -qse "${path}"; then
+				return 0
+			fi
+		done
+		# check load paths
+		if [[ "${#_shwrap_modules_stack[@]}" -gt 0 ]]; then
+			local i stack=("${_shwrap_modules_stack[@]}")
+			unset 'stack[-1]'
+			for i in $(seq 0 "${#stack[@]}" | tac | tail +2); do
+				module_hash="${stack[${i}]}"
+				module_name="${_shwrap_modules_names[${module_hash}]}"
+				module_path="${_shwrap_modules_paths[${module_name}]}"
+				module_dir=$(dirname "${module_path}")
+				if realpath -qse "${module_dir}"/"${module}"; then
+					return 0
+				fi
+			done
+		fi
+		# default
+		if [[ -v SHWRAP_MODULE_PATH ]]; then
+			if realpath -qse "${SHWRAP_MODULE_PATH}"/"${module}"; then
+				return 0
+			fi
+		fi
+	fi
+	# fallback
+	__shwrap_path "${module}"
+}

--- a/src/search.sh
+++ b/src/search.sh
@@ -7,42 +7,43 @@ source "${SHWRAP_INIT_DIR}"/common.sh
 
 function __shwrap_path()
 {
-	local module="$1"
-	realpath -qsm "${module}"
+	local __shwrap_module="$1"
+	realpath -qsm "${__shwrap_module}"
 }
 
 function __shwrap_search()
 {
-	local module="$1"
-	local module_dir module_hash module_name module_path
-	module_path=$(__shwrap_path "${module}")
-	__shwrap_log "__shwrap_search: search '${module}'" >&2
+	local __shwrap_module="$1"
+	local __shwrap_module_hash __shwrap_module_name __shwrap_module_path
+	local module_dir
+	__shwrap_module_path=$(__shwrap_path "${__shwrap_module}")
+	__shwrap_log "__shwrap_search: search '${__shwrap_module}'" >&2
 	# check absolute path
-	if [[ "${module}" == "${module_path}" ]]; then
-		printf '%s' "${module_path}"
+	if [[ "${__shwrap_module}" == "${__shwrap_module_path}" ]]; then
+		printf '%s' "${__shwrap_module_path}"
 		return 0
 	fi
 	# check relative path
 	if [[ "${#_shwrap_modules_stack[@]}" -gt 0 ]]; then
-		module_hash="${_shwrap_modules_stack[-1]}"
-		module_name="${_shwrap_modules_names[${module_hash}]}"
-		module_path="${_shwrap_modules_paths[${module_name}]}"
-		module_dir=$(dirname "${module_path}")
-		if realpath -qse "${module_dir}"/"${module}"; then
+		__shwrap_module_hash="${_shwrap_modules_stack[-1]}"
+		__shwrap_module_name="${_shwrap_modules_names[${__shwrap_module_hash}]}"
+		__shwrap_module_path="${_shwrap_modules_paths[${__shwrap_module_name}]}"
+		module_dir=$(dirname "${__shwrap_module_path}")
+		if realpath -qse "${module_dir}"/"${__shwrap_module}"; then
 			return 0
 		fi
 	fi
 	# check user paths
-	if [[ "${module}" == "${module#./*}" ]] &&
-		   [[ "${module}" == "${module#../*}" ]]; then
+	if [[ "${__shwrap_module}" == "${__shwrap_module#./*}" ]] &&
+		   [[ "${__shwrap_module}" == "${__shwrap_module#../*}" ]]; then
 		for module_dir in "${SHWRAP_MODULE_PATHS[@]}"; do
-			local path="${module_dir}"/"${module}"
+			local path="${module_dir}"/"${__shwrap_module}"
 			if [[ "${module_dir}" == "${module_dir#/*}" ]]; then
 				if [[ "${#_shwrap_modules_stack[@]}" -gt 0 ]]; then
-					module_hash="${_shwrap_modules_stack[-1]}"
-					module_name="${_shwrap_modules_names[${module_hash}]}"
-					module_path="${_shwrap_modules_paths[${module_name}]}"
-					path=$(dirname "${module_path}")/"${module_dir}"/"${module}"
+					__shwrap_module_hash="${_shwrap_modules_stack[-1]}"
+					__shwrap_module_name="${_shwrap_modules_names[${__shwrap_module_hash}]}"
+					__shwrap_module_path="${_shwrap_modules_paths[${__shwrap_module_name}]}"
+					path=$(dirname "${__shwrap_module_path}")/"${module_dir}"/"${__shwrap_module}"
 				fi
 			fi
 			if realpath -qse "${path}"; then
@@ -54,22 +55,22 @@ function __shwrap_search()
 			local i stack=("${_shwrap_modules_stack[@]}")
 			unset 'stack[-1]'
 			for i in $(seq 0 "${#stack[@]}" | tac | tail +2); do
-				module_hash="${stack[${i}]}"
-				module_name="${_shwrap_modules_names[${module_hash}]}"
-				module_path="${_shwrap_modules_paths[${module_name}]}"
-				module_dir=$(dirname "${module_path}")
-				if realpath -qse "${module_dir}"/"${module}"; then
+				__shwrap_module_hash="${stack[${i}]}"
+				__shwrap_module_name="${_shwrap_modules_names[${__shwrap_module_hash}]}"
+				__shwrap_module_path="${_shwrap_modules_paths[${__shwrap_module_name}]}"
+				module_dir=$(dirname "${__shwrap_module_path}")
+				if realpath -qse "${module_dir}"/"${__shwrap_module}"; then
 					return 0
 				fi
 			done
 		fi
 		# default
 		if [[ -v SHWRAP_MODULE_PATH ]]; then
-			if realpath -qse "${SHWRAP_MODULE_PATH}"/"${module}"; then
+			if realpath -qse "${SHWRAP_MODULE_PATH}"/"${__shwrap_module}"; then
 				return 0
 			fi
 		fi
 	fi
 	# fallback
-	__shwrap_path "${module}"
+	__shwrap_path "${__shwrap_module}"
 }

--- a/src/search.sh
+++ b/src/search.sh
@@ -4,6 +4,7 @@
 # search.sh
 # Module search functions.
 
+# shellcheck source=src/common.sh
 source "${SHWRAP_INIT_DIR}"/common.sh
 
 function __shwrap_path()

--- a/src/search.sh
+++ b/src/search.sh
@@ -3,7 +3,7 @@
 # search.sh
 # Module search functions.
 
-source common.sh
+source "${SHWRAP_INIT_DIR}"/common.sh
 
 function __shwrap_path()
 {

--- a/src/search.sh
+++ b/src/search.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # sh.wrap - module system for bash
+
 # search.sh
 # Module search functions.
 
@@ -33,9 +34,9 @@ function __shwrap_search()
 			return 0
 		fi
 	fi
-	# check user paths
 	if [[ "${__shwrap_module}" == "${__shwrap_module#./*}" ]] &&
 		   [[ "${__shwrap_module}" == "${__shwrap_module#../*}" ]]; then
+		# check user paths
 		for module_dir in "${SHWRAP_MODULE_PATHS[@]}"; do
 			local path="${module_dir}"/"${__shwrap_module}"
 			if [[ "${module_dir}" == "${module_dir#/*}" ]]; then

--- a/src/util.sh
+++ b/src/util.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# sh.wrap - module system for bash
+# util.sh
+# Utility functions.
+
+function __shwrap_scope()
+{
+	declare -p | grep -vE '_+shwrap_.*|BASHOPTS|BASH_ARGC|BASH_ARGV|BASH_LINENO|BASH_SOURCE|BASH_VERSINFO|EUID|FUNCNAME|GROUPS|PPID|SHELLOPTS|UID' | __shwrap_declare
+}
+
+function __shwrap_declare()
+{
+	sed -e 's/declare --/declare -g/' |
+		sed -E 's/declare -([^ -]+)/declare -\1g/'
+}
+
+function __shwrap_name_is_function()
+{
+	local name="$1"
+	declare -F "${name}" > /dev/null
+}
+
+function __shwrap_log()
+{
+	local message="$*"
+	[[ -n "${_MODULE_LOG}" ]] && echo "${message}"
+}

--- a/src/util.sh
+++ b/src/util.sh
@@ -27,6 +27,17 @@ function __shwrap_log()
 	[[ -n "${SHWRAP_MODULE_LOG}" ]] && echo "${message}"
 }
 
+function __shwrap_random_bytes()
+{
+	local count="$1"
+	dd if=/dev/urandom bs=1 count="${count}" 2>/dev/null
+}
+
+function __shwrap_md5sum()
+{
+	md5sum | cut -d $' ' -f1
+}
+
 function __shwrap_fd_is_free()
 {
 	local fd="$1"

--- a/src/util.sh
+++ b/src/util.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # sh.wrap - module system for bash
+
 # util.sh
 # Utility functions.
 

--- a/src/util.sh
+++ b/src/util.sh
@@ -16,14 +16,14 @@ function __shwrap_declare()
 
 function __shwrap_name_is_function()
 {
-	local name="$1"
-	declare -F "${name}" > /dev/null
+	local __shwrap_name="$1"
+	declare -F "${__shwrap_name}" > /dev/null
 }
 
 function __shwrap_log()
 {
 	local message="$*"
-	[[ -n "${_MODULE_LOG}" ]] && echo "${message}"
+	[[ -n "${SHWRAP_MODULE_LOG}" ]] && echo "${message}"
 }
 
 function __shwrap_fd_is_free()

--- a/src/util.sh
+++ b/src/util.sh
@@ -5,7 +5,7 @@
 
 function __shwrap_scope()
 {
-	declare -p | grep -vE '_+shwrap_.*|BASHOPTS|BASH_ARGC|BASH_ARGV|BASH_LINENO|BASH_SOURCE|BASH_VERSINFO|EUID|FUNCNAME|GROUPS|PPID|SHELLOPTS|UID' | __shwrap_declare
+	declare -p | grep -vE '_+shwrap_.*|_+SHWRAP_.*|BASHOPTS|BASH_ARGC|BASH_ARGV|BASH_LINENO|BASH_SOURCE|BASH_VERSINFO|EUID|FUNCNAME|GROUPS|PPID|SHELLOPTS|UID' | __shwrap_declare
 }
 
 function __shwrap_declare()

--- a/src/util.sh
+++ b/src/util.sh
@@ -25,3 +25,58 @@ function __shwrap_log()
 	local message="$*"
 	[[ -n "${_MODULE_LOG}" ]] && echo "${message}"
 }
+
+function __shwrap_fd_is_free()
+{
+	local fd="$1"
+	if [[ -e /proc/"$$"/fd/"${fd}" ]]; then
+		return 1
+	fi
+	return 0
+}
+
+function __shwrap_get_fd()
+{
+	local fdr_start="$1"
+	local fdr_end="$2"
+
+	eval "${SHWRAP_FD_FUNC}" "${fdr_start}" "${fdr_end}"
+}
+
+function __shwrap_get_fd_random()
+{
+	local fdr_start="$1"
+	local fdr_end="$2"
+	local fdr_size=$(("${fdr_end}" - "${fdr_start}"))
+	local __fd fd=-1
+	local try=0 maxtry="${SHWRAP_FD_RANDOM_MAXTRY}"
+	while [[ "$((try++))" -lt "${maxtry}" ]]; do
+		__fd=$(("${RANDOM}" % "${fdr_size}" + "${fdr_start}"))
+		if __shwrap_fd_is_free "${__fd}"; then
+			fd="${__fd}"
+			break
+		fi
+	done
+	if [[ "${fd}" == -1 ]]; then
+		__shwrap_log "__shwrap_get_fd: error: no free fd after ${maxtry} tries" >&2
+	fi
+	echo "${fd}"
+}
+
+function __shwrap_get_fd_sequential()
+{
+	local fdr_start="$1"
+	local fdr_end="$2"
+	local __fd fd=-1
+	for __fd in $(seq "${fdr_start}" "${fdr_end}" | head -n -1); do
+		if [[ -v _shwrap_fds["${__fd}"] ]]; then
+			continue
+		fi
+		fd="${__fd}"
+		break
+	done
+	if [[ "${fd}" == -1 ]]; then
+		__shwrap_log "__shwrap_get_fd: error: no free fd after ${maxtry} tries" >&2
+	fi
+	echo "${fd}"
+}


### PR DESCRIPTION
## Add PoC prototype with core functionality

This PoC introduces a concept of module with scope for shell scripts. Current functionality is limited to module search and import.

PoC has no parser, instead it uses combination of \`source\` and \`declare\` to serialize module definitions. Serialized module is injected into a separate shell process spawned with \`env\`.

PoC saves \`module scope\` in special variable \`\_shwrap_scope\`. A module can change its own and other scopes without name collisions.

Usual shell scripts could be imported without changes but with some considerations. In this implementation it\'s preferred if a module contains only function and variable definitions as code execution may affect module functionality in an unexpected manner.

This PoC adds two user commands \`shwrap_import\` and \`shwrap_run\`.

\`shwrap_import\` is for module imports. \`shwrap_run\` is for command execution in a module scope.

### Examples of usage

``` bash
shwrap_import module.sh
shwrap_import module.sh function_name
shwrap_import module.sh function_name1 function_name2 ...

shwrap_run module.sh variable=value
shwrap_run module.sh function_name argument1 argument2 ...
shwrap_run module.sh '{ declare -p; declare -f}'
echo "Hello, sh.wrap!" | shwrap_run module.sh cat
```

When a name is imported from a module it becomes available for usage as a wrapper to \`shwrap\_run\` with the same name. No renaming of imported names is currently supported. Default import (the first example) imports only exported function names (with \`declare -fx\`).

### Module search

Module name could be relative or absolute path. If module name starts with \`./\` or \`../\` its considered a relative. If it starts with \`/\` it is absolute. If it\'s not a relative or absolute path, module is searched in the special locations in order. Firstly \`SHWRAP\_MODULE\_PATHS\` are checked. Module could extend its own search paths by adding relative or absolute paths to this variable. Also user can change it globally. Then load paths are checked. That are the paths of modules that are in the import chain of the module. Then \`SHWRAP\_MODULE\_PATH\` is checked which default is \`\~/.sh.wrap\`. As a fallback we keep current directory if something is broken in the previous search paths.

The order of search:

-   absolute paths
-   relative paths
-   SHWRAP_MODULE_PATHS
-   load paths
-   SHWRAP_MODULE_PATH
-   current directory

For example, these are valid module names

``` bash
shwrap_import /home/username/script.sh # (absolute path)
shwrap_import ./module.sh              # (relative path)
shwrap_import ../../module.sh          # (relative path)
shwrap_import dir/module.sh            # (searched relative to a special locations)
shwrap_import module.sh                # (searched relative to a special locations)
```

### PoC limitations

Limitations of this PoC implementation:

-   no arguments could be passed to modules (TBD)
-   no runnable scripts are supported (as arguments couldn't be passed)
-   user can\'t unset globally exported variables from execution environment with 'unset` command (TBD)
-   names with \`_shwrap_\` and \`_SHWRAP_\` prefixes are considered reserved and shouldn\'t be used
-   limited redirections support (as random file descriptors are used by core functions. TBD)
-   shwrap_import and shwrap_run user functions and core of shwrap don't support scope updates when asynchronously running or running in subshell (because of lack of synchronization)
-   bash is the only supported shell currently. Version 4.3+ or greater (tested in 5.2.2)

Although current PoC implementation supports cyclic module loading (to break \`source\` infinite loops) it\'s better to avoid such cases. Supposed to be changed in future when a syntax parser will be implemented and applied to the core functions. Current logic for cyclic module dependencies is to use partially imported modules at the point where cyclic import occurs. When modules are imported partial imports are fixed.

PoC uses cache when it imports module, so code from module is executed only once (same behavior as in Python).

Issues in this PoC implementation:

-   cache race condition between shell processes. one bash environment could write to cache while other read it
-   possible race on file descriptors (PoC has no support for asynchronous running).
-   performance issues. running command in a module scope in slower because of work that should be done. module import is slow too
-   no return codes checking and no reverting changes for unsuccessful import 
-   when fds are not enough it's broken. for example, it happens on deep imports