### PR TITLE
core: fix: fix SHWRAP_ID is same for different shells

### DIFF
--- a/src/common.sh
+++ b/src/common.sh
@@ -8,7 +8,7 @@
 declare _SHWRAP_ID
 _SHWRAP_ID=$(__shwrap_random_bytes 256 | __shwrap_md5sum)
 
-[[ -n "${SHWRAP_ID}" ]] || declare -x SHWRAP_ID="${_SHWRAP_ID}"
+[[ -n "${SHWRAP_ID}" ]] || declare -g SHWRAP_ID="${_SHWRAP_ID}"
 
 declare -x _SHWRAP_MODULE_PATH=~/.sh.wrap
 declare -x _SHWRAP_MODULE="${SHWRAP_INIT_DIR}"/module.sh

--- a/test/common.spec.sh
+++ b/test/common.spec.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# sh.wrap - module system for bash
+
+# common.spec.sh
+# Module tests for common.sh
+
+# shellcheck disable=SC1091
+
+setup()
+{
+	local SHWRAP_INIT_DIR
+	SHWRAP_INIT_DIR=$(realpath "./src")
+	source "${SHWRAP_INIT_DIR}"/init.sh;
+}
+
+: "test_shwrap_id
+
+This test checks that SHWRAP_ID is not equal for different shells.
+"
+test_shwrap_id()
+{
+	declare -fx setup
+	local shwrap_id_sub
+	shwrap_id_sub=$(bash -c 'setup; echo ${SHWRAP_ID}')
+	[[ -n "${shwrap_id_sub}" ]] && [[ "${SHWRAP_ID}" != "${shwrap_id_sub}" ]]
+}


### PR DESCRIPTION
This PR fixes #48.

```shell
1..1
ok 1 - test_shwrap_id
```