### PR TITLE
core: fix: global variables are not global

### DIFF
--- a/src/common.sh
+++ b/src/common.sh
@@ -5,48 +5,48 @@
 # Common global, environment variables and function definitions for them.
 
 # environment variables
-declare _SHWRAP_ID
+declare -g _SHWRAP_ID
 _SHWRAP_ID=$(__shwrap_random_bytes 256 | __shwrap_md5sum)
 
 [[ -n "${SHWRAP_ID}" ]] || declare -g SHWRAP_ID="${_SHWRAP_ID}"
 
-declare -x _SHWRAP_MODULE_PATH=~/.sh.wrap
-declare -x _SHWRAP_MODULE="${SHWRAP_INIT_DIR}"/module.sh
-declare -x _SHWRAP_TMP_PATH=/tmp/sh.wrap
-declare -ax SHWRAP_MODULE_PATHS
+declare -xg _SHWRAP_MODULE_PATH=~/.sh.wrap
+declare -xg _SHWRAP_MODULE="${SHWRAP_INIT_DIR}"/module.sh
+declare -xg _SHWRAP_TMP_PATH=/tmp/sh.wrap
+declare -axg SHWRAP_MODULE_PATHS
 
 [[ -n "${SHWRAP_MODULE_PATH}" ]] ||
-	declare -x SHWRAP_MODULE_PATH="${_SHWRAP_MODULE_PATH}"
+	declare -xg SHWRAP_MODULE_PATH="${_SHWRAP_MODULE_PATH}"
 [[ -n "${SHWRAP_MODULE}" ]] ||
-	declare -x SHWRAP_MODULE="${_SHWRAP_MODULE}"
+	declare -xg SHWRAP_MODULE="${_SHWRAP_MODULE}"
 [[ -n "${SHWRAP_TMP_PATH}" ]] ||
-	declare -x SHWRAP_TMP_PATH="${_SHWRAP_TMP_PATH}"
+	declare -xg SHWRAP_TMP_PATH="${_SHWRAP_TMP_PATH}"
 [[ -n "${SHWRAP_MODULE_PATHS[*]}" ]] ||
 	SHWRAP_MODULE_PATHS+=(.)
 [[ -d "${SHWRAP_TMP_PATH}" ]] || mkdir -p "${SHWRAP_TMP_PATH}"
 
-declare -ax _SHWRAP_FD_RANGE=(666 777)
-declare -x _SHWRAP_FD_RANDOM_MAXTRY=10
-declare -x _SHWRAP_FD_FUNC=__shwrap_get_fd_sequential
+declare -axg _SHWRAP_FD_RANGE=(666 777)
+declare -xg _SHWRAP_FD_RANDOM_MAXTRY=10
+declare -xg _SHWRAP_FD_FUNC=__shwrap_get_fd_sequential
 
 [[ -n "${SHWRAP_FD_RANGE[*]}" ]] ||
-	SHWRAP_FD_RANGE+=("${_SHWRAP_FD_RANGE[@]}")
+	declare -ag SHWRAP_FD_RANGE+=("${_SHWRAP_FD_RANGE[@]}")
 [[ -n "${SHWRAP_FD_RANDOM_MAXTRY}" ]] ||
-	SHWRAP_FD_RANDOM_MAXTRY="${_SHWRAP_FD_RANDOM_MAXTRY}"
+	declare -g SHWRAP_FD_RANDOM_MAXTRY="${_SHWRAP_FD_RANDOM_MAXTRY}"
 [[ -n "${SHWRAP_FD_FUNC}" ]] ||
-	SHWRAP_FD_FUNC="${_SHWRAP_FD_FUNC}"
+	declare -g SHWRAP_FD_FUNC="${_SHWRAP_FD_FUNC}"
 
 # global variables
-declare -A _shwrap_modules
-declare -A _shwrap_modules_deps
-declare -A _shwrap_modules_hashes
-declare -A _shwrap_modules_names
-declare -A _shwrap_modules_partials
-declare -A _shwrap_modules_parts
-declare -A _shwrap_modules_paths
-declare -A _shwrap_scope
-declare -a _shwrap_fds
-declare -a _shwrap_modules_stack
+declare -Ag _shwrap_modules
+declare -Ag _shwrap_modules_deps
+declare -Ag _shwrap_modules_hashes
+declare -Ag _shwrap_modules_names
+declare -Ag _shwrap_modules_partials
+declare -Ag _shwrap_modules_parts
+declare -Ag _shwrap_modules_paths
+declare -Ag _shwrap_scope
+declare -ag _shwrap_fds
+declare -ag _shwrap_modules_stack
 
 # update global scope
 [[ -v _shwrap_scope[.] ]] || _shwrap_scope+=([.]=$(declare -px))

--- a/src/init.sh
+++ b/src/init.sh
@@ -5,7 +5,7 @@
 # Initialization script intended to be in user shell profile.
 
 [[ -n "${SHWRAP_INIT_DIR}" ]] || SHWRAP_INIT_DIR="${BASH_SOURCE[0]}"
-declare -x SHWRAP_INIT_DIR
+declare -xg SHWRAP_INIT_DIR
 
 # shellcheck source=src/module.sh
 source "${SHWRAP_INIT_DIR}"/module.sh

--- a/test/common.spec.sh
+++ b/test/common.spec.sh
@@ -8,9 +8,23 @@
 
 __init_user()
 {
-	local SHWRAP_INIT_DIR
+	declare -g SHWRAP_INIT_DIR
 	SHWRAP_INIT_DIR=$(realpath "./src")
 	source "${SHWRAP_INIT_DIR}"/init.sh;
+}
+
+__stubs_empty()
+{
+	__shwrap_md5sum() { :; }
+	__shwrap_random_bytes() { :; }
+}
+
+__source()
+{
+	__stubs_empty
+	local shwrap_init_dir
+	shwrap_init_dir=$(realpath "./src")
+	source "${shwrap_init_dir}"/common.sh
 }
 
 : "test_shwrap_id
@@ -24,4 +38,42 @@ test_shwrap_id()
 	local shwrap_id_sub
 	shwrap_id_sub=$(bash -c '__init_user; echo ${SHWRAP_ID}')
 	[[ -n "${shwrap_id_sub}" ]] && [[ "${SHWRAP_ID}" != "${shwrap_id_sub}" ]]
+}
+
+: "test_shwrap_globals
+
+This test checks that global variables are declared global in common.sh module.
+"
+test_common_globals()
+{
+	__source
+	[ -v SHWRAP_ID ]
+	[ -v SHWRAP_FD_FUNC ]
+	[ -v SHWRAP_FD_RANDOM_MAXTRY ]
+	[ -v SHWRAP_FD_RANGE ]
+	[ -v SHWRAP_MODULE ]
+	[ -v SHWRAP_MODULE_PATH ]
+	[ -v SHWRAP_MODULE_PATHS ]
+	[ -v SHWRAP_TMP_PATH ]
+	[ -v _SHWRAP_FD_FUNC ]
+	[ -v _SHWRAP_FD_RANDOM_MAXTRY ]
+	[ -v _SHWRAP_FD_RANGE ]
+	[ -v _SHWRAP_ID ]
+	[ -v _SHWRAP_MODULE ]
+	[ -v _SHWRAP_MODULE_PATH ]
+	[ -v _SHWRAP_TMP_PATH ]
+	# shellcheck disable=SC2154
+	{
+		declare -p _shwrap_modules > /dev/null
+		declare -p _shwrap_modules_deps > /dev/null
+		declare -p _shwrap_modules_hashes > /dev/null
+		declare -p _shwrap_modules_names > /dev/null
+		declare -p _shwrap_modules_partials > /dev/null
+		declare -p _shwrap_modules_parts > /dev/null
+		declare -p _shwrap_modules_paths > /dev/null
+		declare -p _shwrap_scope > /dev/null
+		declare -p _shwrap_fds > /dev/null
+		declare -p _shwrap_fds
+		declare -p _shwrap_modules_stack > /dev/null
+	}
 }

--- a/test/common.spec.sh
+++ b/test/common.spec.sh
@@ -6,7 +6,7 @@
 
 # shellcheck disable=SC1091
 
-setup()
+__init_user()
 {
 	local SHWRAP_INIT_DIR
 	SHWRAP_INIT_DIR=$(realpath "./src")
@@ -19,8 +19,9 @@ This test checks that SHWRAP_ID is not equal for different shells.
 "
 test_shwrap_id()
 {
-	declare -fx setup
+	__init_user
+	declare -fx __init_user
 	local shwrap_id_sub
-	shwrap_id_sub=$(bash -c 'setup; echo ${SHWRAP_ID}')
+	shwrap_id_sub=$(bash -c '__init_user; echo ${SHWRAP_ID}')
 	[[ -n "${shwrap_id_sub}" ]] && [[ "${SHWRAP_ID}" != "${shwrap_id_sub}" ]]
 }

--- a/test/init.spec.sh
+++ b/test/init.spec.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# sh.wrap - module system for bash
+
+# init.spec.1.sh
+# Module tests for init.sh
+
+# shellcheck disable=SC1091
+
+__init_user()
+{
+	declare -g SHWRAP_INIT_DIR
+	SHWRAP_INIT_DIR=$(realpath "./src")
+	source "${SHWRAP_INIT_DIR}"/init.sh;
+}
+
+: "test_init_globals
+
+This test checks that global variables are declared global in init.sh module.
+"
+test_init_globals()
+{
+	__init_user
+	[ -v SHWRAP_INIT_DIR ]
+}


### PR DESCRIPTION
This PR fixes #50.

UPD:
```shell
env -i ./test/microspec/microtap ./test/*.spec.sh
1..5
ok 1 - test_common_globals
ok 2 - test_shwrap_id
ok 3 - test_init_globals
ok 4 - test__shwrap_log_1
ok 5 - test__shwrap_log_2
```
