### PR TITLE
fix: init: initialization error when SHWRAP_INIT_DIR is not set

### DIFF
--- a/src/init.sh
+++ b/src/init.sh
@@ -4,7 +4,7 @@
 # init.sh
 # Initialization script intended to be in user shell profile.
 
-[[ -n "${SHWRAP_INIT_DIR}" ]] || SHWRAP_INIT_DIR="${BASH_SOURCE[0]}"
+[[ -n "${SHWRAP_INIT_DIR}" ]] || SHWRAP_INIT_DIR=$(dirname "${BASH_SOURCE[0]}")
 declare -xg SHWRAP_INIT_DIR
 
 # shellcheck source=src/module.sh

--- a/test/init.spec.sh
+++ b/test/init.spec.sh
@@ -6,6 +6,13 @@
 
 # shellcheck disable=SC1091
 
+__init()
+{
+	local shwrap_init_dir
+	shwrap_init_dir=$(realpath "./src")
+	source "${shwrap_init_dir}"/init.sh
+}
+
 __init_user()
 {
 	declare -g SHWRAP_INIT_DIR
@@ -21,4 +28,13 @@ test_init_globals()
 {
 	__init_user
 	[ -v SHWRAP_INIT_DIR ]
+}
+
+: "test_shwrap_init
+
+This test checks initialization when SHWRAP_INIT_DIR is unset.
+"
+test_shwrap_init()
+{
+	__init
 }


### PR DESCRIPTION
This PR fixes #54, to be merged after #56.

UPD:
```shell
env -i ./test/microspec/microtap ./test/*.spec.sh
1..6
ok 1 - test_common_globals
ok 2 - test_shwrap_id
ok 3 - test_init_globals
ok 4 - test_shwrap_init
ok 5 - test__shwrap_log_1
ok 6 - test__shwrap_log_2
```