### PR TITLE
fix: core: module couldn't set/unset globally exported variables

### DIFF
--- a/src/import.sh
+++ b/src/import.sh
@@ -68,6 +68,7 @@ function __shwrap__import()
 	local __shwrap_i
 	local __shwrap_module_hash __shwrap_module_path __shwrap_partial __shwrap_partial_hash
 	__shwrap_log "__shwrap__import: import '${__shwrap_module}' '${__shwrap_scope}' '${__shwrap_caller}'" >&2
+	_shwrap_scope+=([.]=$(declare -px))
 	if [[ ! -v _shwrap_modules_partials["${__shwrap_module}"] ]]; then
 		# import and cache partially imported modules
 		__shwrap_module_path=$(__shwrap_search "${__shwrap_module}")

--- a/src/run.sh
+++ b/src/run.sh
@@ -65,7 +65,6 @@ function __shwrap__run()
 		'"$(declare -p _shwrap_scope)"'
 		'"$(declare -p _shwrap_fds)"'
 		'"$(declare -p _shwrap_modules_stack)"'
-		eval "${_shwrap_scope[.]}"
 		source '"${SHWRAP_MODULE}"'
 		source /dev/stdin <<< "${_shwrap_modules['"${__shwrap_module_hash}"']}"
 		eval "${_shwrap_scope['"${__shwrap_scope}"']}"
@@ -97,6 +96,7 @@ function __shwrap__run()
 					env -i ${SHWRAP_MODULE_VERBOSE:+-v} \
 						SHWRAP_MODULE_DEBUG="${SHWRAP_MODULE_DEBUG}" \
 						SHWRAP_MODULE_LOG="${SHWRAP_MODULE_LOG}" \
+						SHWRAP_INIT_DIR="${SHWRAP_INIT_DIR}" \
 						"${SHELL}" --noprofile --norc \
 						"${SHWRAP_TMP_PATH}"/"${SHWRAP_ID}"_"${__shwrap_module_hash}"_run.sh "$@"
 					eval "exec ${fd_scope}>&-"
@@ -178,6 +178,7 @@ function __shwrap_cache()
 					env -i ${SHWRAP_MODULE_VERBOSE:+-v} \
 						SHWRAP_MODULE_DEBUG="${SHWRAP_MODULE_DEBUG}" \
 						SHWRAP_MODULE_LOG="${SHWRAP_MODULE_LOG}" \
+						SHWRAP_INIT_DIR="${SHWRAP_INIT_DIR}" \
 						"${SHELL}" --noprofile --norc \
 						"${SHWRAP_TMP_PATH}"/"${SHWRAP_ID}"_"${__shwrap_module_hash}"_cache.sh
 					eval "exec ${fd_out}>&-"

--- a/test/import.spec.sh
+++ b/test/import.spec.sh
@@ -24,3 +24,12 @@ test_set()
 	shwrap_import "${BASH_SOURCE[0]}"
 	shwrap_run "${BASH_SOURCE[0]}" 'test -v GLOBAL_VAR'
 }
+
+test_unset()
+{
+	__init
+	declare -x GLOBAL_VAR=GLOBAL_VAL
+	shwrap_import "${BASH_SOURCE[0]}"
+	shwrap_run "${BASH_SOURCE[0]}" 'unset GLOBAL_VAR'
+	shwrap_run "${BASH_SOURCE[0]}" '! test -v GLOBAL_VAR'
+}

--- a/test/import.spec.sh
+++ b/test/import.spec.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# sh.wrap - module system for bash
+
+# import.spec.sh
+# Module tests for import.sh
+
+# shellcheck disable=SC1091
+
+__init()
+{
+	local shwrap_init_dir
+	shwrap_init_dir=$(realpath "./src")
+	source "${shwrap_init_dir}"/init.sh
+}
+
+: "test_set
+
+This test checks that globally exported variable is visible in the module scope
+"
+test_set()
+{
+	__init
+	declare -x GLOBAL_VAR=GLOBAL_VAL
+	shwrap_import "${BASH_SOURCE[0]}"
+	shwrap_run "${BASH_SOURCE[0]}" 'test -v GLOBAL_VAR'
+}

--- a/test/import.spec.sh
+++ b/test/import.spec.sh
@@ -25,6 +25,10 @@ test_set()
 	shwrap_run "${BASH_SOURCE[0]}" 'test -v GLOBAL_VAR'
 }
 
+: "test_unset
+
+This test checks that module can unset globally exported variable.
+"
 test_unset()
 {
 	__init


### PR DESCRIPTION
This PR fixes #38 and #39.

``` shell
env -i ./test/microspec/microtap ./test/*.spec.sh 
1..8
ok 1 - test_common_globals
ok 2 - test_shwrap_id
ok 3 - test_set
ok 4 - test_unset
ok 5 - test_init_globals
ok 6 - test_shwrap_init
ok 7 - test__shwrap_log_1
ok 8 - test__shwrap_log_2
````